### PR TITLE
fix: Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ train segmentation model
 python generate_segdata.py --img_path original_image_path --out_path watermarked_img_mask_path --weight_path encoder_decoder_pth_path
 
 # train segmentation mode
-python train_seg.py --train_path train_watermarked_img_mask_path --test_path test_watermarked_img_mask_path --output_path pth_output_path
+python train_seg.py --train_path train_watermarked_img_mask_path --val_path test_watermarked_img_mask_path --output_path pth_output_path
 ```
 
 ### evaluating

--- a/train_ed.py
+++ b/train_ed.py
@@ -61,8 +61,8 @@ if __name__ == '__main__':
     discriminator.to(device)
     val_noiser.to(device)
 
-    optimizer = torch.optim.Adamw(encoder_decoder.parameters(), lr=1e-4)
-    optimizer_dis = torch.optim.Adamw(discriminator.parameters(), lr=1e-4)
+    optimizer = torch.optim.AdamW(encoder_decoder.parameters(), lr=1e-4)
+    optimizer_dis = torch.optim.AdamW(discriminator.parameters(), lr=1e-4)
 
     mseloss = torch.nn.MSELoss().to(device)
     binaryloss = torch.nn.BCEWithLogitsLoss().to(device)

--- a/train_seg.py
+++ b/train_seg.py
@@ -18,7 +18,7 @@ parser.add_argument('--H', type=int, default=512)
 parser.add_argument('--W', type=int, default=512)
 parser.add_argument('--start-epoch', default=0, type=int, help='manual epoch number (useful on restarts)')
 parser.add_argument('--weight_decay', default=5e-4, type=float, help='weight decay (default: 1e-4)')
-parser.add_argument('-optimtype', type=str, default='Adamw', help='SGD,Adam,Adamx,Adamw')
+parser.add_argument('-optimtype', type=str, default='AdamW', help='SGD,Adam,Adamx,AdamW')
 parser.add_argument('-lr_schedulertype', type=str, default='CosineAnnealingWarmRestarts', help='CosineAnnealingWarmRestarts,MultiStepLR,ReduceLROnPlateau,CyclicLR')
 parser.add_argument('--train_path', type=str, default='./')
 parser.add_argument('--val_path', type=str, default='./')
@@ -112,7 +112,7 @@ def main(args):
         optimizer = torch.optim.Adam(model.parameters(), args.lr, weight_decay=args.weight_decay)
     elif args.optimtype == 'Adamx':
         optimizer = torch.optim.Adamax(model.parameters(), args.lr, weight_decay=args.weight_decay)
-    elif args.optimtype == 'Adamw':
+    elif args.optimtype == 'AdamW':
         optimizer = torch.optim.AdamW(model.parameters(), args.lr, weight_decay=args.weight_decay)
 
     # select scheduler


### PR DESCRIPTION
在某些较低版本的 torch/python 版本中，可能会触发找不到 AdamW 优化器，改为正确大小写拼写可解决
```
# cherrling @ viper in ~/code/DWSF on git:main x [8:51:24]
$ ./train_ed.sh
Traceback (most recent call last):
  File "train_ed.py", line 64, in <module>
    optimizer = torch.optim.Adamw(encoder_decoder.parameters(), lr=1e-4)
AttributeError: module 'torch.optim' has no attribute 'Adamw'
```